### PR TITLE
Feature/fluent assertions improvements

### DIFF
--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/GenerateExtensionsForInternalTypesAttribute.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/GenerateExtensionsForInternalTypesAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace FunicularSwitch.Generators.FluentAssertions.Templates;
+
+[AttributeUsage(validOn: AttributeTargets.Assembly, AllowMultiple = true)]
+public class GenerateExtensionsForInternalTypesAttribute : Attribute
+{
+    public Type AssemblySpecifier { get; }
+
+    public GenerateExtensionsForInternalTypesAttribute(Type assemblySpecifier)
+    {
+        this.AssemblySpecifier = assemblySpecifier;
+    }
+}

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertions_Result.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertions_Result.cs
@@ -16,7 +16,7 @@ namespace FunicularSwitch.Generators.FluentAssertions.Templates
             Execute.Assertion
                 .ForCondition(this.Subject.IsOk)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context} to be Ok{reason}, but found {0}", this.Subject);
+                .FailWith("Expected {context} to be Ok{reason}, but found {0}", this.Subject.ToString());
 
             return new(this, this.Subject.GetValueOrDefault()!);
         }
@@ -27,7 +27,7 @@ namespace FunicularSwitch.Generators.FluentAssertions.Templates
             Execute.Assertion
                 .ForCondition(this.Subject.IsError)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context} to be Error{reason}, but found {0}", this.Subject);
+                .FailWith("Expected {context} to be Error{reason}, but found {0}", this.Subject.ToString());
 
             return new(this, this.Subject.GetErrorOrDefault()!);
         }

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/OptionAssertions.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/OptionAssertions.cs
@@ -16,7 +16,7 @@ internal class OptionAssertions<T> : ObjectAssertions<FunicularSwitch.Option<T>,
         Execute.Assertion
             .ForCondition(this.Subject.IsSome())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {content} to be Some{reason}, but found {0}", this.Subject);
+            .FailWith("Expected {content} to be Some{reason}, but found {0}", this.Subject.ToString());
 
         return new(this, this.Subject.GetValueOrDefault()!);
     }
@@ -26,7 +26,7 @@ internal class OptionAssertions<T> : ObjectAssertions<FunicularSwitch.Option<T>,
         Execute.Assertion
             .ForCondition(this.Subject.IsNone())
             .BecauseOf(because, becauseArgs)
-            .FailWith("Expected {content} to be None{reason}, but found {0}", this.Subject);
+            .FailWith("Expected {content} to be None{reason}, but found {0}", this.Subject.ToString());
 
         return new(this);
     }

--- a/Source/FunicularSwitch.Generators.FluentAssertions/FunicularSwitch.Generators.FluentAssertions.csproj
+++ b/Source/FunicularSwitch.Generators.FluentAssertions/FunicularSwitch.Generators.FluentAssertions.csproj
@@ -54,6 +54,7 @@
 		<EmbeddedResource Include="..\FunicularSwitch.Generators.FluentAssertions.Templates\MyUnionTypeAssertions_DerivedUnionType.cs" Link="Templates\MyUnionTypeAssertions_DerivedUnionType.cs" />
 		<EmbeddedResource Include="..\FunicularSwitch.Generators.FluentAssertions.Templates\OptionAssertions.cs" Link="Templates\OptionAssertions.cs" />
 		<EmbeddedResource Include="..\FunicularSwitch.Generators.FluentAssertions.Templates\OptionAssertionExtensions.cs" Link="Templates\OptionAssertionExtensions.cs" />
+		<EmbeddedResource Include="..\FunicularSwitch.Generators.FluentAssertions.Templates\GenerateExtensionsForInternalTypesAttribute.cs" Link="Templates\GenerateExtensionsForInternalTypesAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/FunicularSwitch.Generators.FluentAssertions/FunicularSwitch.Generators.FluentAssertions.csproj
+++ b/Source/FunicularSwitch.Generators.FluentAssertions/FunicularSwitch.Generators.FluentAssertions.csproj
@@ -22,7 +22,7 @@
 
 		<!--#region adapt versions here-->
 		<MajorVersion>1</MajorVersion>
-		<MinorAndPatchVersion>0.3</MinorAndPatchVersion>
+		<MinorAndPatchVersion>1.0</MinorAndPatchVersion>
 		<!--#endregion-->
 
 		<AssemblyVersion>$(MajorVersion).0.0</AssemblyVersion>

--- a/Source/FunicularSwitch.Generators.FluentAssertions/Templates/GenerateFluentAssertionsForTemplates.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions/Templates/GenerateFluentAssertionsForTemplates.cs
@@ -11,6 +11,7 @@ internal class GenerateFluentAssertionsForTemplates
     public static string MyDerivedUnionTypeAssertions => Resources.ReadResource("MyUnionTypeAssertions_DerivedUnionType.cs");
     public static string OptionAssertions => Resources.ReadResource("OptionAssertions.cs");
     public static string OptionAssertionExtensions => Resources.ReadResource("OptionAssertionExtensions.cs");
+    public static string GenerateExtensionsForInternalTypesAttribute => Resources.ReadResource("GenerateExtensionsForInternalTypesAttribute.cs");
 }
 
 internal static class Resources

--- a/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer.Dependency/ExampleResult.cs
+++ b/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer.Dependency/ExampleResult.cs
@@ -55,3 +55,10 @@ public class WrapperClass
         public sealed record OtherDerivedNestedUnionType_(string Message) : NestedUnionType;
     }
 }
+
+[UnionType(CaseOrder = CaseOrder.AsDeclared)]
+internal abstract record InternalUnionType
+{
+    public sealed record First(string Text) : InternalUnionType;
+    public sealed record Second(string Text) : InternalUnionType;
+}

--- a/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer.Dependency/ExampleResult.cs
+++ b/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer.Dependency/ExampleResult.cs
@@ -20,6 +20,11 @@ public abstract partial class MyError
         }
 
         public int Number { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(FirstCase)}: {nameof(this.Number)} = {this.Number}";
+        }
     }
 
     public sealed class SecondCase_ : MyError
@@ -30,6 +35,11 @@ public abstract partial class MyError
         }
 
         public string Text { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(SecondCase)}: {nameof(this.Text)} = {this.Text}";
+        }
     }
 }
 

--- a/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer/OptionMethods.cs
+++ b/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer/OptionMethods.cs
@@ -24,9 +24,11 @@ public class OptionMethods
         // ARRANGE
         var option = Option.Some(23);
 
+
         // ASSERT
         Action(() => option.Should().BeNone())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("23");
     }
 
     [Fact]
@@ -47,6 +49,7 @@ public class OptionMethods
 
         // ASSERT
         Action(() => option.Should().BeSome())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("None");
     }
 }

--- a/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer/ResultMethods.cs
+++ b/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer/ResultMethods.cs
@@ -38,18 +38,20 @@ public class ResultMethods
 
         // ASSERT
         Action(() => result.Should().BeError())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("Test");
     }
 
     [Fact]
     public void StockResult_Error_ShouldNotBeOk()
     {
         // ARRANGE
-        var result = Result.Error<string>("Error");
+        var result = Result.Error<string>("ErrorText");
 
         // ASSERT
         Action(() => result.Should().BeOk())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("ErrorText");
     }
 
     [Fact]
@@ -107,7 +109,8 @@ public class ResultMethods
 
         // ASSERT
         Action(() => result.Should().BeError())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("Test");
     }
 
     [Fact]
@@ -119,7 +122,8 @@ public class ResultMethods
         // ASSERT
         Action(() => result.Should().BeError()
                 .Which.Should().BeFirstCase())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("Test");
     }
 
     [Fact]
@@ -131,7 +135,8 @@ public class ResultMethods
         // ASSERT
         Action(() => result.Should().BeError()
                 .Which.Should().BeSecondCase())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("Test");
     }
 
     [Fact]
@@ -142,7 +147,8 @@ public class ResultMethods
 
         // ASSERT
         Action(() => result.Should().BeOk())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("FirstCase").And.Contain("5");
     }
 
     [Fact]
@@ -154,7 +160,8 @@ public class ResultMethods
         // ASSERT
         Action(() => result.Should().BeError()
                 .Which.Should().BeSecondCase())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("FirstCase").And.Contain("5");
     }
 
 
@@ -166,7 +173,8 @@ public class ResultMethods
 
         // ASSERT
         Action(() => result.Should().BeOk())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("SecondCase").And.Contain("Test");
     }
 
     [Fact]
@@ -178,6 +186,7 @@ public class ResultMethods
         // ASSERT
         Action(() => result.Should().BeError()
                 .Which.Should().BeFirstCase())
-            .Should().Throw<XunitException>();
+            .Should().Throw<XunitException>()
+            .Which.UserMessage.Should().Contain("SecondCase").And.Contain("Test");
     }
 }

--- a/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer/UnionTypeMethods.cs
+++ b/Source/Tests/FunicularSwitch.Generators.FluentAssertions.Consumer/UnionTypeMethods.cs
@@ -1,6 +1,9 @@
 ﻿using FluentAssertions;
+using FunicularSwitch;
 using FunicularSwitch.Generators.FluentAssertions.Consumer.Dependency;
 using Xunit.Sdk;
+
+//[assembly: GenerateExtensionsForInternalTypes(typeof(ExampleResult))]
 
 namespace FunicularSwitch.Generators.FluentAssertions.Consumer;
 


### PR DESCRIPTION
Result (and Option) no longer show {empty} if .Should().BeOk() fails
Generate Assertion Extensions only for public types, and internal if specific assembly attribute is set