### PR TITLE
Set #nullable enable on all generated files

### DIFF
--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/GenerateExtensionsForInternalTypesAttribute.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/GenerateExtensionsForInternalTypesAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace FunicularSwitch.Generators.FluentAssertions.Templates;
 

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertionExtensions_Result.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertionExtensions_Result.cs
@@ -1,4 +1,5 @@
-﻿//additional using directives
+﻿#nullable enable
+//additional using directives
 
 namespace FunicularSwitch.Generators.FluentAssertions.Templates
 {

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertionExtensions_UnionType.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertionExtensions_UnionType.cs
@@ -1,4 +1,5 @@
-﻿//additional using directives
+﻿#nullable enable
+//additional using directives
 
 namespace FunicularSwitch.Generators.FluentAssertions.Templates
 {

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertions_Result.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertions_Result.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions.Execution;
+﻿#nullable enable
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using FluentAssertions;
 //additional using directives

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertions_UnionType.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyAssertions_UnionType.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions.Primitives;
+﻿#nullable enable
+using FluentAssertions.Primitives;
 //additional using directives
 
 namespace FunicularSwitch.Generators.FluentAssertions.Templates

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyErrorType.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyErrorType.cs
@@ -1,4 +1,5 @@
-﻿namespace FunicularSwitch.Generators.FluentAssertions.Templates
+﻿#nullable enable
+namespace FunicularSwitch.Generators.FluentAssertions.Templates
 {
     public abstract class MyErrorType
     {

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyResult.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyResult.cs
@@ -1,4 +1,5 @@
-﻿namespace FunicularSwitch.Generators.FluentAssertions.Templates
+﻿#nullable enable
+namespace FunicularSwitch.Generators.FluentAssertions.Templates
 {
     [ResultType(ErrorType = typeof(MyErrorType))]
     public abstract partial class MyResult { }

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyUnionType.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyUnionType.cs
@@ -1,4 +1,5 @@
-﻿namespace FunicularSwitch.Generators.FluentAssertions.Templates
+﻿#nullable enable
+namespace FunicularSwitch.Generators.FluentAssertions.Templates
 {
     [UnionType(CaseOrder = CaseOrder.AsDeclared)]
     public abstract partial record MyUnionType

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyUnionTypeAssertions_DerivedUnionType.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/MyUnionTypeAssertions_DerivedUnionType.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿#nullable enable
+using FluentAssertions;
 using FluentAssertions.Execution;
 //additional using directives
 

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/OptionAssertionExtensions.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/OptionAssertionExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace FunicularSwitch.Generators.FluentAssertions.Templates;
+﻿#nullable enable
+namespace FunicularSwitch.Generators.FluentAssertions.Templates;
 
 internal static class OptionAssertionExtensions
 {

--- a/Source/FunicularSwitch.Generators.FluentAssertions.Templates/OptionAssertions.cs
+++ b/Source/FunicularSwitch.Generators.FluentAssertions.Templates/OptionAssertions.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions.Execution;
+﻿#nullable enable
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using FluentAssertions;
 using System;

--- a/Source/FunicularSwitch.Generators.FluentAssertions/FunicularSwitch.Generators.FluentAssertions.csproj
+++ b/Source/FunicularSwitch.Generators.FluentAssertions/FunicularSwitch.Generators.FluentAssertions.csproj
@@ -23,7 +23,7 @@
 
 		<!--#region adapt versions here-->
 		<MajorVersion>1</MajorVersion>
-		<MinorAndPatchVersion>3.1</MinorAndPatchVersion>
+		<MinorAndPatchVersion>3.2</MinorAndPatchVersion>
 		<!--#endregion-->
 
 		<AssemblyVersion>$(MajorVersion).0.0</AssemblyVersion>

--- a/Source/FunicularSwitch.Generators.Templates/EnumTypeAttributes.cs
+++ b/Source/FunicularSwitch.Generators.Templates/EnumTypeAttributes.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/FunicularSwitch.Generators.Templates/MyError.cs
+++ b/Source/FunicularSwitch.Generators.Templates/MyError.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿#nullable enable
+using System.Linq;
 
 namespace FunicularSwitch.Generators.Templates
 {

--- a/Source/FunicularSwitch.Generators.Templates/ResultTypeAttributes.cs
+++ b/Source/FunicularSwitch.Generators.Templates/ResultTypeAttributes.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/FunicularSwitch.Generators.Templates/UnionTypeAttributes.cs
+++ b/Source/FunicularSwitch.Generators.Templates/UnionTypeAttributes.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/FunicularSwitch.Generators/FunicularSwitch.Generators.csproj
+++ b/Source/FunicularSwitch.Generators/FunicularSwitch.Generators.csproj
@@ -17,7 +17,7 @@
 
 		<!--#region adapt versions here-->
 		<MajorVersion>4</MajorVersion>
-		<MinorAndPatchVersion>2.2</MinorAndPatchVersion>
+		<MinorAndPatchVersion>2.3</MinorAndPatchVersion>
 		<!--#endregion-->
 
 		<VersionSuffixLocal />

--- a/Source/FunicularSwitch.Generators/UnionType/Generator.cs
+++ b/Source/FunicularSwitch.Generators/UnionType/Generator.cs
@@ -16,6 +16,7 @@ public static class Generator
     {
         var builder = new CSharpBuilder();
         builder.WriteLine("#pragma warning disable 1591");
+        builder.WriteLine("#nullable enable");
 
         //builder.WriteLine($"//Generator runs: {RunCount.Increase(unionTypeSchema.FullTypeName)}");
 

--- a/Source/FunicularSwitch/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.EnumTypeGenerator/Attributes.g.cs
+++ b/Source/FunicularSwitch/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.EnumTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/FunicularSwitch/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.ResultTypeGenerator/Attributes.g.cs
+++ b/Source/FunicularSwitch/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.ResultTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/FunicularSwitch/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/Attributes.g.cs
+++ b/Source/FunicularSwitch/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.EnumTypeGenerator/Attributes.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.EnumTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.ResultTypeGenerator/Attributes.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.ResultTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/Attributes.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/StandardMinLangVersionMyUnionMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer.StandardMinLangVersion/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/StandardMinLangVersionMyUnionMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace StandardMinLangVersion
 {
 	public static partial class MyUnionMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.EnumTypeGenerator/Attributes.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.EnumTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.ResultTypeGenerator/Attributes.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.ResultTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/Attributes.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/Attributes.g.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 // ReSharper disable once CheckNamespace
 namespace FunicularSwitch.Generators

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerArgumentExceptionMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerArgumentExceptionMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	public static partial class ArgumentExceptionMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerCardTypeMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerCardTypeMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	internal static partial class CardTypeMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerErrorMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerErrorMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	public static partial class ErrorMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerFailureMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerFailureMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	public static partial class FailureMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerGenericResultOfT_TFailureMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerGenericResultOfT_TFailureMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	public static partial class GenericResultMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerIUnionMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerIUnionMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	public static partial class IUnionMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerSystemArgumentExceptionMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerSystemArgumentExceptionMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer.System
 {
 	public static partial class ArgumentExceptionMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerWithPrimaryConstructorMatchExtension.g.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Consumer/Generated/FunicularSwitch.Generators/FunicularSwitch.Generators.UnionTypeGenerator/FunicularSwitchGeneratorsConsumerWithPrimaryConstructorMatchExtension.g.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Generators.Consumer
 {
 	public static partial class WithPrimaryConstructorMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_embedded#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_embedded#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_embedded#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_embedded#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_embedded#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_embedded#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_with_order#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_with_order#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_with_order#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_with_order#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_with_order#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_enum_match_method_generator.For_enum_type_with_order#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_enum_error_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_enum_error_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_enum_error_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_enum_error_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_enum_error_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_enum_error_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_in_different_namespace#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_in_different_namespace#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_in_different_namespace#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_in_different_namespace#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_in_different_namespace#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_in_different_namespace#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_with_merge#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_with_merge#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_with_merge#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_with_merge#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_with_merge#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_error_type_with_merge#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_internal_result_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_internal_result_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_internal_result_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_internal_result_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_internal_result_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_internal_result_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_result_type_without_namespace#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_result_type_without_namespace#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_result_type_without_namespace#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_result_type_without_namespace#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_result_type_without_namespace#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_result_type_generator.For_result_type_without_namespace#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#OuterBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_empty_namespace#OuterBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: OuterBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 public static partial class BaseMatchExtension
 {
 	public static T Match<T>(this Outer.Base @base, global::System.Func<Outer.One, T> one, global::System.Func<Outer.Two, T> two) =>

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_explicitly_internal_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	internal static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_implicitly_internal_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	internal static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_inaccessible_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_inaccessible_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_inaccessible_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_inaccessible_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_inaccessible_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_inaccessible_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#FunicularSwitchTestIBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_interface_union_type#FunicularSwitchTestIBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestIBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class IBaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#FunicularSwitchTestOuterBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_nested_record_union_type#FunicularSwitchTestOuterBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestOuterBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#FunicularSwitchTestBase2MatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#FunicularSwitchTestBase2MatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBase2MatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	internal static partial class Base2MatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_partial_record_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	internal static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_as_declared_case_order#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_explicit_case_order#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_record_union_type_with_multi_level_concrete_derived_types#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#FunicularSwitchTestFieldTypeMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_switchyard_union_type#FunicularSwitchTestFieldTypeMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestFieldTypeMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class FieldTypeMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#FunicularSwitchTestBaseTypeOfTMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_with_generic_base_class#FunicularSwitchTestBaseTypeOfTMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseTypeOfTMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseTypeMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_without_derived_types#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_without_derived_types#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_without_derived_types#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_without_derived_types#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_without_derived_types#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.For_union_type_without_derived_types#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#FunicularSwitchTestIBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_interface_union_type#FunicularSwitchTestIBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestIBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class IBaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#FunicularSwitchTestOuterInitResultMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_nested_internal_union_type#FunicularSwitchTestOuterInitResultMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestOuterInitResultMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	internal static partial class InitResultMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#FunicularSwitchTestBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Static_factories_for_type_with_required_properties#FunicularSwitchTestBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class BaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#FunicularSwitchTestIBaseBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_derived_interface#FunicularSwitchTestIBaseBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestIBaseBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class IBaseBaseMatchExtension

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#Attributes.g.00.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#Attributes.g.00.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#Attributes.g.01.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#Attributes.g.01.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#Attributes.g.02.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#Attributes.g.02.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: Attributes.g.cs
+#nullable enable
 using System;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#FunicularSwitchTestIBaseMatchExtension.g.verified.cs
+++ b/Source/Tests/FunicularSwitch.Generators.Test/Snapshots/Run_union_type_generator.Support_structs_derived_from_interface#FunicularSwitchTestIBaseMatchExtension.g.verified.cs
@@ -1,5 +1,6 @@
 ﻿//HintName: FunicularSwitchTestIBaseMatchExtension.g.cs
 #pragma warning disable 1591
+#nullable enable
 namespace FunicularSwitch.Test
 {
 	public static partial class IBaseMatchExtension


### PR DESCRIPTION
feat: set #nullable enable on all generated files such that when passing null to a non-nullable type the compiler issues a warning